### PR TITLE
fix: change `project.entry-points.console_scripts` to `project.scripts` in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ keywords = ["gaussian"]
 homepage = "https://github.com/njzjz/gaussianrunner"
 repository = "https://github.com/njzjz/gaussianrunner"
 
-[project.entry-points.console_scripts]
+[project.scripts]
 datasetbuilder = "mddatasetbuilder.datasetbuilder:_commandline"
 qmcalc = "mddatasetbuilder.qmcalc:_commandline"
 preparedeepmd = "mddatasetbuilder.deepmd:_commandline"


### PR DESCRIPTION
`project.entry-points.console_scripts` is not allowed per [PEP 621](https://peps.python.org/pep-0621/).